### PR TITLE
metadata units fix

### DIFF
--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -532,7 +532,7 @@
 [sfc_wts]
   standard_name = surface_stochastic_weights_from_coupled_process
   long_name = weights for stochastic surface physics perturbation
-  units = none
+  units = 1
   dimensions = (horizontal_loop_extent,number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys

--- a/physics/GFS_surface_generic.meta
+++ b/physics/GFS_surface_generic.meta
@@ -310,7 +310,7 @@
 [sfc_wts]
   standard_name = surface_stochastic_weights_from_coupled_process
   long_name = weights for stochastic surface physics perturbation
-  units = none
+  units = 1
   dimensions = (horizontal_loop_extent,number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys


### PR DESCRIPTION
change units of surface_stochastic_weights_from_coupled_process from none to 1 to match change in fv3atm